### PR TITLE
Switch dynamic factory_bot attrs to static

### DIFF
--- a/lib/solidus_digital_assets/factories.rb
+++ b/lib/solidus_digital_assets/factories.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
   end
 
   factory :digital_asset, class: Spree::DigitalAsset do
-    name 'abc'
+    name { 'abc' }
   end
 
 end


### PR DESCRIPTION
Fixes a very noisy deprecation from `factory_bot` about dynamic factory
attributes.