### PR TITLE
Remove link from breadcrumb

### DIFF
--- a/app/views/spree/admin/digital_assets/index.html.erb
+++ b/app/views/spree/admin/digital_assets/index.html.erb
@@ -1,5 +1,5 @@
 <% admin_layout "full-width" %>
-<% admin_breadcrumb(link_to(plural_resource_name(Spree::DigitalAsset.new), [:admin, Spree::DigitalAsset])) %>
+<% admin_breadcrumb(plural_resource_name(Spree::DigitalAsset.new)) %>
 <% folder_breadcrumb_path(@current_folder) %>
 
 <% content_for :page_actions do %>


### PR DESCRIPTION
This removes the link part of the breadcrumb. It was previously linking to the page it was currently on and didn't match the rest of the admin.

Review app: https://github.com/geminimvp/engine_storefront/pull/1351