### PR TITLE
Update button helpers to button_tag

### DIFF
--- a/app/views/spree/admin/digital_assets/edit.html.erb
+++ b/app/views/spree/admin/digital_assets/edit.html.erb
@@ -8,7 +8,7 @@
       <%= render :partial => 'form', locals: { f: f } %>
       <div class="form-group">
         <div class="col-md-offset-4 col-md-6">
-          <%= button I18n.t('spree.actions.update'), 'save' %>
+          <%= button_tag I18n.t('spree.actions.update'), class: 'fa fa-save' %>
           <span class="or"><%= I18n.t(:or, scope: :spree) %></span>
           <%= button_link_to I18n.t('spree.actions.cancel'), spree.admin_digital_assets_url(folder_id: @digital_asset.folder_id), icon: 'delete', id: 'cancel_link' %>
         </div>

--- a/app/views/spree/admin/digital_assets/index.html.erb
+++ b/app/views/spree/admin/digital_assets/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :page_actions do %>
   <% if can? :manage, Spree::DigitalAsset %>
-    <%= button I18n.t(create_folder_button_text(@current_folder), scope: :spree), nil, 'button', id: 'admin_new_folder', data: { toggle: 'modal', target: '#add-subfolder' } %>
+    <%= button_tag I18n.t(create_folder_button_text(@current_folder), scope: :spree), class: 'btn btn-primary', id: 'admin_new_folder', data: { toggle: 'modal', target: '#add-subfolder' } %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Solidus deprecated the `button` helper in v2.8, so we switch to the
`button_tag` method instead.

Solidus change reference: https://github.com/solidusio/solidus/pull/2600